### PR TITLE
restrict ci branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
 name: ci
 on:
   push:
+    branches:
+      - main
+      - v[0-9]
+      - v[0-9][0-9]
   workflow_dispatch:
   pull_request:
     types:


### PR DESCRIPTION
only run on release branches