### PR TITLE
Resolve SHA pins to release tags in script/release-train

### DIFF
--- a/script/release-train
+++ b/script/release-train
@@ -6,31 +6,113 @@ set -e
 
 REPO_DIR="$(CDPATH="" cd -- "$(dirname -- "$0")/.." && pwd -P)"
 
-action_dl() {
+CANONICAL_REPO="WillAbides/release-train"
+RELEASE_DOWNLOAD_BASE="https://github.com/$CANONICAL_REPO/releases/download"
+CANONICAL_GIT_URL="https://github.com/$CANONICAL_REPO.git"
+
+# looks_like_release_tag returns 0 if $1 looks like a semver release tag (vX.Y.Z...).
+looks_like_release_tag() {
+  case "$1" in
+    v[0-9]*.[0-9]*.[0-9]*) return 0 ;;
+  esac
+  return 1
+}
+
+# is_full_sha returns 0 if $1 is a 40-character hex string.
+is_full_sha() {
+  case "$1" in
+    *[!0-9a-fA-F]* | '') return 1 ;;
+  esac
+  [ "${#1}" -eq 40 ]
+}
+
+# resolve_sha_to_tag prints a semver release tag from the canonical repo that points at
+# the given commit SHA. Returns non-zero if ls-remote fails or no matching tag is found.
+resolve_sha_to_tag() {
+  _rstt_sha="$1"
+  _rstt_refs="$(git ls-remote --tags "$CANONICAL_GIT_URL" 2>/dev/null)" || return 1
+  _rstt_tag="$(printf '%s\n' "$_rstt_refs" | awk -v sha="$_rstt_sha" '
+    $1 == sha {
+      ref = $2
+      sub(/^refs\/tags\//, "", ref)
+      sub(/\^\{\}$/, "", ref)
+      if (ref ~ /^v[0-9]+\.[0-9]+\.[0-9]+/) {
+        print ref
+        exit
+      }
+    }
+  ')"
+  [ -n "$_rstt_tag" ] || return 1
+  printf '%s\n' "$_rstt_tag"
+}
+
+# determine_release_tag prints the release-train release tag that should be downloaded
+# based on the action's pinned ref, or returns non-zero to indicate that the script should
+# fall back to building from source.
+determine_release_tag() {
+  [ -n "$GITHUB_ACTION_PATH" ] || return 1
+  _drt_raw="$(basename "$GITHUB_ACTION_PATH")"
+
+  if looks_like_release_tag "$_drt_raw"; then
+    printf '%s\n' "$_drt_raw"
+    return 0
+  fi
+
+  # Only resolve a SHA when the action is pinned against the canonical repo. Forks at
+  # the same SHA can have tags pointing at unrelated source we cannot safely map to a
+  # canonical release.
+  _drt_repo="${GITHUB_ACTION_REPOSITORY:-$CANONICAL_REPO}"
+  [ "$_drt_repo" = "$CANONICAL_REPO" ] || return 1
+
+  is_full_sha "$_drt_raw" || return 1
+
+  _drt_tag="$(resolve_sha_to_tag "$_drt_raw")" || return 1
+  echo "Resolved action commit $_drt_raw to release tag $_drt_tag" >&2
+  printf '%s\n' "$_drt_tag"
+}
+
+# download_release downloads bindown.yaml for the given release tag and installs
+# release-train into bin/. Any failure here is fatal: the user explicitly pinned to a
+# released version, so silently falling back to a source build would mask the problem.
+download_release() {
   (
-    [ -n "$GITHUB_ACTION_PATH" ] || return 1
+    _dr_tag="$1"
     cd "$REPO_DIR"
-    ACTION_VERSION="$(basename "$GITHUB_ACTION_PATH")"
-    echo "Using release-train version $ACTION_VERSION from action"
+    echo "Using release-train version $_dr_tag from action"
 
-    mkdir -p tmp
-    rm -f tmp/bindown.yaml
+    mkdir -p tmp bin
+    rm -f tmp/bindown.yaml bin/release-train
 
-    curl -L -o tmp/bindown.yaml \
-      "https://github.com/WillAbides/release-train/releases/download/$ACTION_VERSION/bindown.yaml"
+    if ! curl --fail --silent --show-error --location \
+      --output tmp/bindown.yaml \
+      "$RELEASE_DOWNLOAD_BASE/$_dr_tag/bindown.yaml"; then
+      echo "release-train: failed to download bindown.yaml for $_dr_tag from $RELEASE_DOWNLOAD_BASE/$_dr_tag/bindown.yaml" >&2
+      return 1
+    fi
 
-    script/bindown install release-train --configfile tmp/bindown.yaml --cache .cache --output bin/release-train
-    echo "Successfully downloaded release-train $ACTION_VERSION from action" >&2
+    if ! script/bindown install release-train \
+      --configfile tmp/bindown.yaml --cache .cache --output bin/release-train; then
+      echo "release-train: failed to install release-train $_dr_tag via bindown" >&2
+      return 1
+    fi
+
+    echo "Successfully downloaded release-train $_dr_tag from action" >&2
   )
 }
 
 local_build() {
   (
     cd "$REPO_DIR"
+    mkdir -p bin
+    rm -f bin/release-train
     go build -o bin/release-train .
   )
 }
 
-action_dl || local_build
+if RELEASE_TAG="$(determine_release_tag)"; then
+  download_release "$RELEASE_TAG"
+else
+  local_build
+fi
 
 exec "$REPO_DIR"/bin/release-train "$@"

--- a/script/release-train
+++ b/script/release-train
@@ -30,7 +30,7 @@ is_full_sha() {
 # the given commit SHA. Returns non-zero if ls-remote fails or no matching tag is found.
 resolve_sha_to_tag() {
   _rstt_sha="$1"
-  _rstt_refs="$(git ls-remote --tags "$CANONICAL_GIT_URL" 2>/dev/null)" || return 1
+  _rstt_refs="$(git ls-remote --tags "$CANONICAL_GIT_URL" 2> /dev/null)" || return 1
   _rstt_tag="$(printf '%s\n' "$_rstt_refs" | awk -v sha="$_rstt_sha" '
     $1 == sha {
       ref = $2


### PR DESCRIPTION
Fixes #193

## Problem

When the action is pinned by commit SHA (e.g. `uses: WillAbides/release-train@<sha>`), `basename "$GITHUB_ACTION_PATH"` in `script/release-train` returns the SHA instead of a release tag. That produces a download URL like

```
https://github.com/WillAbides/release-train/releases/download/<sha>/bindown.yaml
```

which 404s. `curl -L -o` happily writes the 404 HTML page to `tmp/bindown.yaml`, bindown then fails parsing it, and the failure is masked by `action_dl || local_build`. Most consumers don't have `go` on the runner, so what they actually see is a confusing `go: command not found` / `go.mod not found` error far removed from the real cause.

## Fix

`script/release-train` now decides what to do based on the basename of `$GITHUB_ACTION_PATH`:

- **`vX.Y.Z`-shaped** → download `bindown.yaml` for that release. Any download/install failure is **fatal** — silently falling back to a source build would defeat the point of pinning to a released version.
- **Full 40-hex SHA pinned against canonical `WillAbides/release-train`** → resolve the SHA to a release tag via `git ls-remote --tags https://github.com/WillAbides/release-train.git`, then treat as a release. Forks at the same SHA are intentionally **not** trusted — a fork could carry a `vX.Y.Z` tag pointing at unrelated source.
- **Anything else** (branch name like `main`, fork SHA, short SHA, local checkout, unresolved SHA) → fall through to `go build` with a clear log message instead of attempting a download that's guaranteed to 404.

Additional hardening:

- `curl --fail --silent --show-error --location` so a 404 surfaces as an error instead of a 200-with-HTML body.
- Explicit error checks around `curl` and `bindown install` with diagnostic messages.
- Remove any stale `bin/release-train` before install so a failed install can't exec a previous build.
- `git ls-remote` output is captured before being piped through `awk` so a network failure isn't lost to POSIX-sh's lack of `pipefail`.

## Notes / follow-ups

- The script remains POSIX `#!/bin/sh` and passes `bin/shellcheck` (per `script/lint`).
- `git` is assumed available on the runner. It's effectively guaranteed on GitHub-hosted runners and on any runner using `actions/checkout`. If `git ls-remote` fails, the script logs and falls back to local build.
- An alternative implementation discussed in #193 was to bake a `VERSION` file into the release artifacts. That would avoid the runtime network call but requires non-trivial release-workflow changes (the release runs from detached `HEAD` so the new file would need a separate commit path). Happy to do that as a follow-up if preferred.

## Validation

- `bin/shellcheck script/*` passes.
- New helper functions (`looks_like_release_tag`, `is_full_sha`, `resolve_sha_to_tag`, `determine_release_tag`) were spot-tested locally against the scenarios above, including resolving the actual `cd01ea9e19bb396bf659f61e1c840c5174b92de8` SHA from the issue → `v3.8.5`.
- `go test ./...` passes.
- `script/release-train --generate-action` produces an unchanged `action.yml`.