### PR TITLE
bump golangci-lint to v2.12.2

### DIFF
--- a/.bindown.yaml
+++ b/.bindown.yaml
@@ -19,7 +19,7 @@ dependencies:
   golangci-lint:
     template: origin#golangci-lint
     vars:
-      version: 2.1.6
+      version: 2.12.2
   goreleaser:
     template: origin#goreleaser
     vars:
@@ -411,10 +411,10 @@ url_checksums:
   https://github.com/cli/cli/releases/download/v2.29.0/gh_2.29.0_macOS_amd64.zip: e116d0f9c310450482cdcd7f4d2d1c7c4cab8d4f025a340260ce3f15329c5145
   https://github.com/cli/cli/releases/download/v2.29.0/gh_2.29.0_macOS_arm64.zip: 38ca9a355376abd1475362cf8b3cacf2a757198fe5fe70349cb1767666abacc6
   https://github.com/cli/cli/releases/download/v2.29.0/gh_2.29.0_windows_amd64.zip: 031eb343ebff6f8cc712d58d79267ee00b0c61b37d6698927161daae895044c6
-  https://github.com/golangci/golangci-lint/releases/download/v2.1.6/golangci-lint-2.1.6-darwin-amd64.tar.gz: e091107c4ca7e283902343ba3a09d14fb56b86e071effd461ce9d67193ef580e
-  https://github.com/golangci/golangci-lint/releases/download/v2.1.6/golangci-lint-2.1.6-darwin-arm64.tar.gz: 90783fa092a0f64a4f7b7d419f3da1f53207e300261773babe962957240e9ea6
-  https://github.com/golangci/golangci-lint/releases/download/v2.1.6/golangci-lint-2.1.6-linux-amd64.tar.gz: e55e0eb515936c0fbd178bce504798a9bd2f0b191e5e357768b18fd5415ee541
-  https://github.com/golangci/golangci-lint/releases/download/v2.1.6/golangci-lint-2.1.6-windows-amd64.zip: fd7298019c76cf414ab083491f87f6c0a3e537ed6d727d6ff9135e503d6f9c32
+  https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-amd64.tar.gz: f6f06d94b6241521c53d15450c5209b028270bf966f842afb11c030c79f5bc16
+  https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-arm64.tar.gz: a9c54498731b3128f79e090be6110f3e5fffccc617b08142ed244d4126c73f29
+  https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz: 8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553
+  https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-windows-amd64.zip: bd42e3ebc8cb4ececb86941983baaf1dc221bbb04d838e94ce63b49cc91e02bb
   https://github.com/goreleaser/goreleaser/releases/download/v1.18.2/goreleaser_Darwin_arm64.tar.gz: 7eec9f4d0b86b2c9c9f6af1770a11315998bd4d4617633b0a73eeb036e97393e
   https://github.com/goreleaser/goreleaser/releases/download/v1.18.2/goreleaser_Darwin_x86_64.tar.gz: 95338eed333347152e23837b68a8c6ce0c62b9f5abb68bd5b4b08178766400b9
   https://github.com/goreleaser/goreleaser/releases/download/v1.18.2/goreleaser_Linux_x86_64.tar.gz: 811e0c63e347f78f3c8612a19ca8eeb564eb45f0265ce3f38aec39c8fdbcfa10

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@
 
 # yaml-language-server: $schema=https://raw.githubusercontent.com/golangci/golangci-lint/refs/heads/main/jsonschema/golangci.jsonschema.json
 
-## Golden config for golangci-lint v2.1.6
+## Golden config for golangci-lint v2.12.2
 #
 # This is the best config for golangci-lint based on my experience and opinion.
 # It is very strict, but not extremely strict.
@@ -387,22 +387,14 @@ linters:
       - common-false-positives
     # Excluding configuration per-path, per-linter, per-text and per-source.
     rules:
-      - source: 'TODO'
-        linters: [godot]
       - text: 'should have a package comment'
         linters: [revive]
       - text: 'var-naming: '
         linters: [revive]
       - text: 'exported \S+ \S+ should have comment( \(or a comment on this block\))? or be unexported'
         linters: [revive]
-      - text: 'package comment should be of the form ".+"'
-        source: '// ?(nolint|TODO)'
-        linters: [revive]
       - text: 'ST1003' # identifier capitalization
         linters: [staticcheck]
-      - text: 'comment on exported \S+ \S+ should be of the form ".+"'
-        source: '// ?(nolint|TODO)'
-        linters: [revive, staticcheck]
       - path: '_test\.go'
         linters:
           - bodyclose

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 var version = "dev"
 
 func helpVars() kong.Vars {
-	return kong.Vars{
+	return kong.Vars{ //nolint:gosec // G101 false positive: help text mentioning "token" is not a credential
 		"generate_action_help":  `Ignore all other flags and generate a GitHub action.`,
 		"ref_help":              `git ref.`,
 		"checkout_dir_help":     `The directory where the repository is checked out.`,


### PR DESCRIPTION
The pinned `golangci-lint` v2.1.6 was built with go1.24 and panics on Go 1.26 stdlib files when running locally. Bump it to v2.12.2 (built with go1.26) and clean up the fallout.

- `.bindown.yaml`: bump `golangci-lint` to v2.12.2
- `main.go`: suppress a gosec G101 false positive on the kong help-text map (the word "token" in the help string trips the hardcoded-credentials check)
- `.golangci.yml`: drop three exclusion rules that no longer match anything (surfaced by `warn-unused: true` after the upgrade); update the version comment

`script/lint` now exits 0 with no warnings.